### PR TITLE
Handle token and id in the header

### DIFF
--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -5,9 +5,13 @@ export class ApiService {
   private baseURL: string;
   private defaultHeaders: HeadersInit;
 
-  //handling header data(token). the token will be saved in the field called "Authorization"
+  //handling header data(token and userId). the token and userId will be saved in the field called "Authorization"
   private authToken: string | null = null;
+  private userId: string | null = null;
+
   setAuthToken(token: string) { this.authToken = token;}
+  setUserId(id: string) { this.userId = id; }
+
   private getHeaders(): HeadersInit {
     const headers: Record<string, string> = {
       "Content-Type": "application/json"
@@ -17,6 +21,10 @@ export class ApiService {
       console.log("Using auth token for request:", this.authToken);
       headers["Authorization"] = this.authToken;
     }
+    if (this.userId) {
+      headers["User-Id"] = this.userId;
+    }
+    
     return headers;
   }
 

--- a/app/api/apiService.ts
+++ b/app/api/apiService.ts
@@ -5,6 +5,22 @@ export class ApiService {
   private baseURL: string;
   private defaultHeaders: HeadersInit;
 
+  //handling header data(token). the token will be saved in the field called "Authorization"
+  private authToken: string | null = null;
+  setAuthToken(token: string) { this.authToken = token;}
+  private getHeaders(): HeadersInit {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json"
+    };
+
+    if (this.authToken){
+      console.log("Using auth token for request:", this.authToken);
+      headers["Authorization"] = this.authToken;
+    }
+    return headers;
+  }
+
+
   constructor() {
     this.baseURL = getApiDomain();
     this.defaultHeaders = {
@@ -64,7 +80,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "GET",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
     });
     return this.processResponse<T>(
       res,
@@ -82,7 +98,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "POST",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
       body: JSON.stringify(data),
     });
     return this.processResponse<T>(
@@ -101,7 +117,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "PUT",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
       body: JSON.stringify(data),
     });
     return this.processResponse<T>(
@@ -119,7 +135,7 @@ export class ApiService {
     const url = `${this.baseURL}${endpoint}`;
     const res = await fetch(url, {
       method: "DELETE",
-      headers: this.defaultHeaders,
+      headers: this.getHeaders(),
     });
     return this.processResponse<T>(
       res,

--- a/app/hooks/useApi.ts
+++ b/app/hooks/useApi.ts
@@ -6,6 +6,8 @@ import useLocalStorage from "./useLocalStorage";
 
 export const useApi = () => {
   const {value: token} = useLocalStorage('token',null);
+  const {value: userId} = useLocalStorage('id', null);
+
 
   return useMemo(() =>{
     const service = new ApiService();
@@ -13,7 +15,10 @@ export const useApi = () => {
     if (token) {
       service.setAuthToken(token);
     }
+    if (userId) {
+      service.setUserId(userId);
+    }
     return service;
-  },[token]);
+  },[token, userId]);
 
 };

--- a/app/hooks/useApi.ts
+++ b/app/hooks/useApi.ts
@@ -1,6 +1,19 @@
 import { ApiService } from "@/api/apiService";
 import { useMemo } from "react"; // think of usememo like a singleton, it ensures only one instance exists
+import useLocalStorage from "./useLocalStorage";
+
+
 
 export const useApi = () => {
-  return useMemo(() => new ApiService(), []); // only if ApiService changes, the memo gets updated and useEffect in app/users/page.tsx gets triggered
+  const {value: token} = useLocalStorage('token',null);
+
+  return useMemo(() =>{
+    const service = new ApiService();
+
+    if (token) {
+      service.setAuthToken(token);
+    }
+    return service;
+  },[token]);
+
 };


### PR DESCRIPTION
 I edited the useApi.ts and apiService.ts
so the token and userId can be sent to the backend using headers.(as it was implemented in M1).

this means you don't have to do anything different if you had the token and userid in the body.

you can now use

"""
const {
    set: setToken, // we need this method to set the value of the token to the one we receive from the POST request to the backend server API
  } = useLocalStorage<string>("token", ""); // note that the key we are selecting is "token" and the default value we are setting is an empty string
  const {
    set: setStoredUserId,
  } = useLocalStorage<number | null>("storedUserId", null);

"""
to save the userid and token in the localstorage(during login)